### PR TITLE
Reorganize readme to make more easily consumable

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Here are some settings you may need to configure in your Application configurati
       </dependencies>
     ```
 
+To see how classes within the SDK can be used to call APIs, refer to [this example](samples/java-rest-api-clients/src/main/java/org/alfresco/java/rest/client/sample/service/RESTClientService.java)
+
 ### Usage in a non-spring application
 
 You can check the documentation here:

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/README.md
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/README.md
@@ -1,5 +1,5 @@
 # Alfresco APA Java REST API
 
-Usage and Build notes can be in the [top level README](../../README.md). This module contains the code used to generate the individual REST APIs within the SDK.
+Usage and Build notes are in the [top level README](../../README.md). This module contains the code used to generate the individual REST APIs and the API code once generated.
 
 APIs that will be generated are each represented with a pom file in their respective folders [here](generated).


### PR DESCRIPTION
The diff is pretty messy, but basically what I did was merge the contents of the README in alfresco-apa-java-rest-api\alfresco-apa-java-rest-api-lib into the main README and massage the wording in order to flow better. Since there is only a single SDK In this repo it seemed unnecessary to spread the instructions for building or using the SDK across multiple files. 

However, there are some bits that may still need tweaking - specifically around authentication, I don't know if some of the configuration was only relevant for ACS (noted in comments).