### PR TITLE
Add usage notes for maven license plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,3 +336,52 @@ Running on GitHub requires the following environment variables to be set:
 |----------------|------------------------------------|
 | MAVEN_USERNAME | Internal Maven repository username |
 | MAVEN_PASSWORD | Internal Maven repository password |
+
+## License Management
+
+Modules in this repo use the following Maven plugins to perform licensing related tasks:
+
+- [com.mycila:license-maven-plugin](https://mycila.carbou.me/license-maven-plugin/) is used for checking and updating the license header on all applicable files. This is typically done at the beginning of a new year.
+- [org.codehaus.mojo:license-maven-plugin](https://www.mojohaus.org/license-maven-plugin/) is used to manage third party licenses. Specifically generating a report of all licenses used by dependencies.
+
+Since these plugins have the same name (excluding the groupId), running them requires qualifiying the goal with the full name.
+
+### Updating the license header
+
+To check that the license header is consistent across all source files, run this command:
+
+`mvn com.mycila:license-maven-plugin:check`
+
+If any source files have a modified or missing license header, this goal will fail.
+
+To fix the license header on all source files, run this command:
+
+`mvn com.mycila:license-maven-plugin:format`
+
+Any files that did not have the correct header will be reformatted and appear in your unstaged changes.
+
+You can use this command to update the license header when the Copyright year should be updated. Before running the format goal, modify [pom.xml](pom.xml) with the current year:
+
+```xml
+<properties>
+    <project.year>year-here</project.year>
+</properties>
+```
+
+See the [plugin documentation](https://mycila.carbou.me/license-maven-plugin/) for all possible goals.
+
+### Listing Third Party Licenses
+
+To list all third party licenses across all modules, the following command can be used:
+
+``mvn org.codehaus.mojo:license-maven-plugin:aggregate-third-party-report``
+
+This will create a file located at `.\target\site\aggregate-third-party-report.html`, which contains a list of the licenses for all dependencies for all modules.
+
+Additionally, per-module text-based reports can be created with this command:
+
+`mvn org.codehaus.mojo:license-maven-plugin:add-third-party`
+
+For each module a file will be created at `target\generated-sources\license\THIRD-PARTY.txt`
+
+See the [plugin documentation](https://www.mojohaus.org/license-maven-plugin/) for all possible goals.

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/pom.xml
@@ -344,12 +344,6 @@
                   <goal>format</goal>
                 </goals>
               </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>com.mycila</groupId>
-            <artifactId>license-maven-plugin</artifactId>
-            <executions>
               <execution>
                 <id>validate-license</id>
                 <phase>process-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,9 @@
           <artifactId>license-maven-plugin</artifactId>
           <version>${license-maven-plugin.version}</version>
           <configuration>
-            <inlineHeader><![CDATA[
+            <licenseSets>
+              <licenseSet>
+                <inlineHeader><![CDATA[
 Copyright ${project.inceptionYear}-${project.year} ${project.organization.name}.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -164,10 +166,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.]]>
-            </inlineHeader>
-            <includes>
-              <include>**/*.java</include>
-            </includes>
+                </inlineHeader>
+                <includes>
+                  <include>**/*.java</include>
+                </includes>
+              </licenseSet>
+            </licenseSets>
             <mapping>
               <java>SLASHSTAR_STYLE</java>
             </mapping>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <spring-cloud.version>2020.0.3</spring-cloud.version>
     <swagger-core.version>1.5.20</swagger-core.version>
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
-    <third-party-license-maven-plugin.version>2.0.1.alfresco-1</third-party-license-maven-plugin.version>
+    <third-party-license-maven-plugin.version>2.0.1.alfresco-2</third-party-license-maven-plugin.version>
   </properties>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,6 @@ limitations under the License.]]>
                 <failOnMissing>true</failOnMissing>
                 <excludedScopes>provided,test</excludedScopes>
                 <excludedGroups>^(org\.alfresco|com\.alfresco|org\.activiti|org\.gytheio).*</excludedGroups>
-                <failIfWarning>true</failIfWarning>
                 <includedLicenses>https://raw.githubusercontent.com/Alfresco/third-party-license-overrides/master/includedLicenses.txt</includedLicenses>
                 <licenseMergesUrl>https://raw.githubusercontent.com/Alfresco/third-party-license-overrides/master/licenseMerges.txt</licenseMergesUrl>
                 <overrideUrl>https://raw.githubusercontent.com/Alfresco/third-party-license-overrides/master/override-THIRD-PARTY.properties</overrideUrl>


### PR DESCRIPTION
I found the license headers were out of date (Copyright year), so I started playing around with the license plugins specified in the poms. I added instructions to README.md for future use.

I also updated the configuration of one of the plugins as it was generating a deprecated warning.