### PR TITLE
AAE-13594 Simplify the versioning process for the SDK modules

### DIFF
--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-audit-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-audit-rest-api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-apa-java-rest-api-lib</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>alfresco-activiti-audit-rest-api</artifactId>
   <name>alfresco-activiti-audit-rest-api</name>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-deployment-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-deployment-rest-api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-apa-java-rest-api-lib</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>alfresco-activiti-deployment-rest-api</artifactId>
   <name>alfresco-activiti-deployment-rest-api</name>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-dmn-simulation-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-dmn-simulation-rest-api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-apa-java-rest-api-lib</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>alfresco-activiti-dmn-simulation-rest-api</artifactId>
   <name>alfresco-activiti-dmn-simulation-rest-api</name>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-form-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-form-rest-api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-apa-java-rest-api-lib</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>alfresco-activiti-form-rest-api</artifactId>
   <name>alfresco-activiti-form-rest-api</name>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-modeling-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-modeling-rest-api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-apa-java-rest-api-lib</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>alfresco-activiti-modeling-rest-api</artifactId>
   <name>alfresco-activiti-modeling-rest-api</name>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-preference-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-preference-rest-api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-apa-java-rest-api-lib</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>alfresco-activiti-preference-rest-api</artifactId>
   <name>alfresco-activiti-preference-rest-api</name>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-query-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-query-rest-api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-apa-java-rest-api-lib</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>alfresco-activiti-query-rest-api</artifactId>
   <name>alfresco-activiti-query-rest-api</name>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-rest-api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-apa-java-rest-api-lib</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>alfresco-activiti-rest-api</artifactId>
   <name>alfresco-activiti-rest-api</name>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-runtime-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-runtime-rest-api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-apa-java-rest-api-lib</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>alfresco-activiti-runtime-rest-api</artifactId>
   <name>alfresco-activiti-runtime-rest-api</name>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-script-modeling-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/generated/alfresco-activiti-script-modeling-rest-api/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-apa-java-rest-api-lib</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>alfresco-activiti-script-modeling-rest-api</artifactId>
   <name>alfresco-activiti-script-modeling-rest-api</name>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>alfresco-apa-java-rest-api</artifactId>
     <groupId>org.alfresco</groupId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>alfresco-apa-java-rest-api-lib</artifactId>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/pom.mustache
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-lib/src/main/resources/templates/libraries/spring-cloud/pom.mustache
@@ -5,12 +5,12 @@
   <parent>
     <groupId>@project.groupId@</groupId>
     <artifactId>@project.artifactId@</artifactId>
-    <version>@project.version@</version>
+    <version>${revision}</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>{{artifactId}}</artifactId>
   <name>{{artifactId}}</name>
-  <version>{{artifactVersion}}</version>
+  <version>${revision}</version>
   <dependencies>
   {{#useOas2}}
     <dependency>

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-spring-boot-starter/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>alfresco-apa-java-rest-api</artifactId>
     <groupId>org.alfresco</groupId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-spring-boot/pom.xml
+++ b/alfresco-apa-java-rest-api/alfresco-apa-java-rest-api-spring-boot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>alfresco-apa-java-rest-api</artifactId>
     <groupId>org.alfresco</groupId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/alfresco-apa-java-rest-api/pom.xml
+++ b/alfresco-apa-java-rest-api/pom.xml
@@ -5,10 +5,9 @@
   <parent>
     <artifactId>alfresco-process-sdk</artifactId>
     <groupId>org.alfresco</groupId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-
   <packaging>pom</packaging>
 
   <modules>

--- a/alfresco-java-rest-api-common/pom.xml
+++ b/alfresco-java-rest-api-common/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-process-sdk</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>alfresco-java-rest-api-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>org.alfresco</groupId>
   <artifactId>alfresco-process-sdk</artifactId>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <name>Alfresco :: Process SDK :: Parent</name>
   <description>Parent for Alfresco Process SDK</description>
@@ -81,6 +81,7 @@
   </distributionManagement>
 
 <properties>
+    <revision>7.10.0-SNAPSHOT</revision>
     <project.scm.organisation>Alfresco</project.scm.organisation>
     <project.scm.repository>alfresco-process-sdk</project.scm.repository>
     <project.year>2023</project.year>

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,11 @@ limitations under the License.]]>
             <deployAtEnd>true</deployAtEnd>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>1.4.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -227,7 +232,31 @@ limitations under the License.]]>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-       </plugin>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+        </configuration>
+        <executions>
+          <!-- enable flattening -->
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <!-- ensure proper cleanup -->
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/samples/java-rest-api-clients/pom.xml
+++ b/samples/java-rest-api-clients/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-process-sdk-samples</artifactId>
-    <version>7.10.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/samples/java-rest-api-clients/src/main/java/org/alfresco/java/rest/client/sample/RESTClientSampleApplication.java
+++ b/samples/java-rest-api-clients/src/main/java/org/alfresco/java/rest/client/sample/RESTClientSampleApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2021 Alfresco Software, Ltd.
+ * Copyright 2021-2023 Alfresco Software, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.alfresco.java.rest.client.sample;
 
 import org.springframework.boot.SpringApplication;

--- a/samples/java-rest-api-clients/src/main/java/org/alfresco/java/rest/client/sample/service/RESTClientService.java
+++ b/samples/java-rest-api-clients/src/main/java/org/alfresco/java/rest/client/sample/service/RESTClientService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2021 Alfresco Software, Ltd.
+ * Copyright 2021-2023 Alfresco Software, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.alfresco.java.rest.client.sample.service;
 
 import org.alfresco.activiti.audit.handler.AuditEventsControllerImplApi;

--- a/samples/java-rest-api-clients/src/test/java/org/alfresco/java/rest/client/sample/RESTClientSampleApplicationTest.java
+++ b/samples/java-rest-api-clients/src/test/java/org/alfresco/java/rest/client/sample/RESTClientSampleApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2021 Alfresco Software, Ltd.
+ * Copyright 2021-2023 Alfresco Software, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -5,15 +5,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.9</version>
-    <relativePath/>
+    <groupId>org.alfresco</groupId>
+    <artifactId>alfresco-process-sdk</artifactId>
+    <version>${revision}</version>
   </parent>
 
   <groupId>org.alfresco</groupId>
   <artifactId>alfresco-process-sdk-samples</artifactId>
-  <version>7.10.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <name>Alfresco :: Process SDK :: Samples</name>
   <description>Sample application using the Process SDK</description>


### PR DESCRIPTION
Maven has [a feature](https://maven.apache.org/maven-ci-friendly.html) that makes it possible to control the version of all modules in a single place. This will simplify future tasks to increment the version of the SDK. Even with automation in place, it's better if only a single file needs to be modified. Once these changes are made, modifying the version for the entire SDK should entail just changing the <revision> property in the top level pom.

This was accomplished by updating each child pom to use the special property `${revision}` instead of specifying the version directly. This tells maven to use the revision property as defined in the top level parent pom. `revision` is a special maven property and must be named as such.

Most of the changes in this PR are updating pom's to use the revision property. The pom.mustache file also was updated so that generated pom files are correct. Finally, I changed the code sample poms to use the parent pom of the repo (previously they were not) - doing so required adding the copyright headers.

This article was used as reference: https://blog.soebes.io/posts/2017/04/2017-04-02-maven-pom-files-without-a-version-in-it/