### PR TITLE
AAE-13594: Fix versioning due to flatted poms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,8 @@ limitations under the License.]]>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
         <configuration>
+          <updatePomFile>true</updatePomFile>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
         </configuration>
         <executions>
           <!-- enable flattening -->


### PR DESCRIPTION
I was missing some configuration that will take maven to use the flatted poms (containing the actual version) instead of the original poms containing the placeholder ${revisoin}