### PR TITLE
Fixing artifacts deploy step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
   <modules>
     <module>alfresco-apa-java-rest-api</module>
     <module>alfresco-java-rest-api-common</module>
-    <module>samples</module>
   </modules>
   <scm>
     <url>http://github.com/${project.scm.organisation}/${project.scm.repository}</url>

--- a/samples/java-rest-api-clients/pom.xml
+++ b/samples/java-rest-api-clients/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.alfresco</groupId>
     <artifactId>alfresco-process-sdk-samples</artifactId>
-    <version>${revision}</version>
+    <version>7.10.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -38,13 +38,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
+
     </plugins>
   </build>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -5,14 +5,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.alfresco</groupId>
-    <artifactId>alfresco-process-sdk</artifactId>
-    <version>${revision}</version>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.9</version>
   </parent>
 
   <groupId>org.alfresco</groupId>
   <artifactId>alfresco-process-sdk-samples</artifactId>
-  <version>${revision}</version>
+  <version>7.10.0</version>
   <packaging>pom</packaging>
   <name>Alfresco :: Process SDK :: Samples</name>
   <description>Sample application using the Process SDK</description>
@@ -30,12 +30,6 @@
           <configuration>
             <skip>true</skip>
           </configuration>
-          <executions>
-            <execution>
-              <id>default-deploy</id>
-              <phase>none</phase>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -43,15 +37,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-        <executions>
-          <execution>
-            <id>default-deploy</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
The sample projects (which are not deployed) were overriding the deploy for the non-sample projects, so that nothing was deployed.