### PR TITLE
AAE-22211 Remove Maven propagation to acceptance tests

### DIFF
--- a/.jx/updatebot.yaml
+++ b/.jx/updatebot.yaml
@@ -3,7 +3,6 @@ kind: UpdateConfig
 spec:
   rules:
     - urls:
-        - https://github.com/Alfresco/alfresco-process-acceptance-tests
         - https://github.com/Alfresco/alfresco-process-releases
       reusePullRequest: true
       changes:


### PR DESCRIPTION
After the removal of Java code from acceptance tests we don't need to propagation the parent pom version anymore